### PR TITLE
Docker compose won't attach to network when monitoring is enabled during install

### DIFF
--- a/lib/cmd_start.sh
+++ b/lib/cmd_start.sh
@@ -55,12 +55,26 @@ cmd_start() {
     log_success "Logos Node container started"
     log_info "Waiting for node to initialize..."
 
-    if docker_health_wait 120; then
+    local health_rc
+    docker_health_wait 120 && health_rc=0 || health_rc=$?
+
+    if [[ $health_rc -eq 0 ]]; then
         echo ""
         log_success "Node is running and healthy!"
         echo ""
-        # Show brief status
         _show_brief_status
+    elif [[ $health_rc -eq 2 ]]; then
+        echo ""
+        log_error "Node container exited unexpectedly"
+        log_info "Last log lines:"
+        echo ""
+        $DOCKER_CMD logs --tail 30 "$LOGOS_CONTAINER_NAME" 2>&1 | while IFS= read -r line; do
+            echo -e "  ${DIM}${line}${RESET}"
+        done || true
+        echo ""
+        log_info "For the full log run: ${BOLD}logosup logs${RESET}"
+        log_info "hahahah"
+        return 1
     else
         echo ""
         log_warn "Node started but health check hasn't passed yet"

--- a/lib/cmd_start.sh
+++ b/lib/cmd_start.sh
@@ -73,7 +73,6 @@ cmd_start() {
         done || true
         echo ""
         log_info "For the full log run: ${BOLD}logosup logs${RESET}"
-        log_info "hahahah"
         return 1
     else
         echo ""

--- a/lib/docker.sh
+++ b/lib/docker.sh
@@ -334,12 +334,57 @@ docker_cleanup_legacy_network() {
     $DOCKER_CMD network rm logos-net &>/dev/null || true
 }
 
+# Repair a `logosnode-net` network that exists but was NOT created by compose.
+#
+# Both stacks declare this network with `name: logosnode-net` (see
+# generate_compose_file and the monitoring compose). Compose refuses to adopt a
+# same-named network that lacks its own labels, aborting with "network
+# logosnode-net was found but has incorrect label" — which breaks `start`.
+#
+# This bites installs done before the monitoring stack switched from
+# `external: true` + a manual `docker network create` to a compose-managed
+# network: that manual network has no compose labels, and on those boxes the
+# monitoring containers are already attached to it, so it isn't orphaned and
+# can't simply be removed in place.
+#
+# Fix: when the network is unmanaged, bring our stacks down to detach from it,
+# drop it, and let the normal bring-up recreate it with the right labels (the
+# node and monitoring stacks are restarted by the regular flow right after).
+# No-op when the network is already compose-managed or absent, so healthy
+# installs are untouched. Idempotent; never force-disconnects foreign
+# containers — if a non-compose workload holds the name, `network rm` simply
+# fails and the (now surfaced) compose error tells the operator.
+docker_repair_unmanaged_network() {
+    $DOCKER_CMD network inspect logosnode-net &>/dev/null || return 0
+
+    # Compose always tags networks it owns with com.docker.compose.network=<key>;
+    # our key is "logosnode-net". Anything else (empty/manual) is unmanaged.
+    local net_label
+    net_label="$($DOCKER_CMD network inspect logosnode-net \
+        --format '{{index .Labels "com.docker.compose.network"}}' 2>/dev/null)" || true
+    [[ "$net_label" == "logosnode-net" ]] && return 0
+
+    log_warn "Found a 'logosnode-net' network not managed by compose — repairing it"
+    log_dim "Detaching and recreating it so compose can adopt it cleanly"
+
+    # Detach our containers by bringing both stacks down. Data lives in named
+    # volumes, so this is safe; both are (re)started by the normal flow after.
+    local mon_compose="$LOGOS_NODE_DIR/docker-compose.monitoring.yml"
+    if [[ -f "$mon_compose" ]]; then
+        COMPOSE_IGNORE_ORPHANS=true $DOCKER_COMPOSE -f "$mon_compose" down &>/dev/null || true
+    fi
+    $DOCKER_COMPOSE -f "$(get_compose_path)" down &>/dev/null || true
+
+    $DOCKER_CMD network rm logosnode-net &>/dev/null || true
+}
+
 # Start the node
 docker_up() {
     local compose_path
     compose_path="$(get_compose_path)"
 
     docker_cleanup_legacy_network
+    docker_repair_unmanaged_network
     $DOCKER_COMPOSE -f "$compose_path" up -d
 }
 

--- a/lib/docker.sh
+++ b/lib/docker.sh
@@ -338,8 +338,9 @@ docker_cleanup_legacy_network() {
 docker_up() {
     local compose_path
     compose_path="$(get_compose_path)"
-    $DOCKER_COMPOSE -f "$compose_path" up -d
+
     docker_cleanup_legacy_network
+    $DOCKER_COMPOSE -f "$compose_path" up -d
 }
 
 # Stop the node
@@ -354,20 +355,32 @@ docker_is_running() {
     $DOCKER_CMD ps --filter "name=${LOGOS_CONTAINER_NAME}" --format '{{.Names}}' 2>/dev/null | grep -q "^${LOGOS_CONTAINER_NAME}$"
 }
 
-# Wait for the node to become healthy
+# Wait for the node to become healthy.
+# Returns:
+#   0  — container reached "healthy"
+#   1  — timed out (container still running but not yet healthy)
+#   2  — container exited/crashed
 docker_health_wait() {
     local timeout="${1:-120}"
     local elapsed=0
 
     while [[ $elapsed -lt $timeout ]]; do
+        # Bail out early if the container is not running
+        if ! docker_is_running; then
+            echo -en "\r\033[K"
+            return 2
+        fi
+
         local status
         status="$($DOCKER_CMD inspect --format='{{.State.Health.Status}}' "$LOGOS_CONTAINER_NAME" 2>/dev/null)" || true
 
         case "$status" in
             healthy)
+                echo -en "\r\033[K"
                 return 0
                 ;;
             unhealthy)
+                echo -en "\r\033[K"
                 return 1
                 ;;
         esac

--- a/lib/monitoring.sh
+++ b/lib/monitoring.sh
@@ -155,7 +155,7 @@ services:
 
 networks:
   logosnode-net:
-    external: true
+    name: logosnode-net
 COMPOSE
 
     log_success "Monitoring compose file generated at $compose_path"
@@ -178,11 +178,6 @@ monitoring_build() {
 }
 
 monitoring_up() {
-    # Ensure the shared network exists (monitoring may start before the node)
-    if ! $DOCKER_CMD network inspect logosnode-net &>/dev/null; then
-        $DOCKER_CMD network create logosnode-net &>/dev/null || true
-    fi
-
     local compose_path
     compose_path="$(get_monitoring_compose_path)"
     COMPOSE_IGNORE_ORPHANS=true $DOCKER_COMPOSE -f "$compose_path" up -d

--- a/lib/monitoring.sh
+++ b/lib/monitoring.sh
@@ -178,6 +178,12 @@ monitoring_build() {
 }
 
 monitoring_up() {
+    # Monitoring may come up before the node (during install, or `monitor start`
+    # on a stopped node). If a stale, non-compose `logosnode-net` lingers from an
+    # older install, repair it first so compose can adopt the shared network
+    # cleanly instead of aborting on a label mismatch. No-op on healthy installs.
+    docker_repair_unmanaged_network
+
     local compose_path
     compose_path="$(get_monitoring_compose_path)"
     COMPOSE_IGNORE_ORPHANS=true $DOCKER_COMPOSE -f "$compose_path" up -d


### PR DESCRIPTION
The problem is [this code](https://github.com/strudelPi/logosup/blob/main/lib/monitoring.sh#L182-L184). When during an installation user decides to enable monitoring the monitoring stack is ran before the node stack. This means the network won't exist and the this code creates the network manually.

But when later docker-compose tries to bring up the node, it won't attach to the network because the network is not a docker-compose managed network (doesn't have the compose labels). It gets refused and fails. The second commit basically just lets compose always decide whether to create/attach the network which will always be compose managed. (Another way to go would be to use `external` for both networks but that would mean you need to create the network on several different places in code, which I like less).

The first commit basically is only correctly surfacing the errors that might happen, because originally when I tried this on `main` I would only get the 120s timeout for spinning up the docker compose and no specific error:
- the healthy check does not account for the container actually not being alive (which it isn't because the docker-compose fails on the network problem. 
- the network problem also is not surfaced because the function `docker_up()` returns the last call (the legacy cleanup) and ignored the previous errors.


Tested this with installing both w/ the monitoring stack during install and w/o (and enabling the monitoring stack later).