### PR TITLE
docs: Raspberry Pi workshop guide for Logos Circle Lisbon

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ Missing prerequisites are auto-installed via the system package manager (apt, dn
 ## Links
 
 - [Logos Blockchain quickstart guide](https://github.com/logos-co/logos-docs/blob/main/docs/blockchain/get-started/run-a-logos-blockchain-node-from-cli.md)
-- [Manual CLI install guide](https://github.com/logos-co/logos-docs/blob/main/docs/blockchain/get-started/run-a-logos-blockchain-node-from-cli.md) — for production/mainnet without logosup
 - [Logos Blockchain releases](https://github.com/logos-blockchain/logos-blockchain/releases/)
 - [Testnet faucet](https://testnet.blockchain.logos.co/web/faucet/) · [Testnet dashboard](https://testnet.blockchain.logos.co/web/)
 - [Logos website](https://logos.co/)

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Missing prerequisites are auto-installed via the system package manager (apt, dn
 ## Links
 
 - [Logos Blockchain quickstart guide](https://github.com/logos-co/logos-docs/blob/main/docs/blockchain/quickstart-guide-for-the-logos-blockchain-node.md)
+- [Manual CLI install guide](https://github.com/logos-co/logos-docs/blob/main/docs/blockchain/get-started/run-a-logos-blockchain-node-from-cli.md) — for production/mainnet without logosup
 - [Logos Blockchain releases](https://github.com/logos-blockchain/logos-blockchain/releases/)
 - [Testnet faucet](https://testnet.blockchain.logos.co/web/faucet/) · [Testnet dashboard](https://testnet.blockchain.logos.co/web/)
 - [Logos website](https://logos.co/)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Missing prerequisites are auto-installed via the system package manager (apt, dn
 
 ## Links
 
-- [Logos Blockchain quickstart guide](https://github.com/logos-co/logos-docs/blob/main/docs/blockchain/quickstart-guide-for-the-logos-blockchain-node.md)
+- [Logos Blockchain quickstart guide](https://github.com/logos-co/logos-docs/blob/main/docs/blockchain/get-started/run-a-logos-blockchain-node-from-cli.md)
 - [Manual CLI install guide](https://github.com/logos-co/logos-docs/blob/main/docs/blockchain/get-started/run-a-logos-blockchain-node-from-cli.md) — for production/mainnet without logosup
 - [Logos Blockchain releases](https://github.com/logos-blockchain/logos-blockchain/releases/)
 - [Testnet faucet](https://testnet.blockchain.logos.co/web/faucet/) · [Testnet dashboard](https://testnet.blockchain.logos.co/web/)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 # Installation & Docker setup
 
-`logosup` automates the full [Logos Blockchain quickstart](https://github.com/logos-co/logos-docs/blob/main/docs/blockchain/quickstart-guide-for-the-logos-blockchain-node.md) flow.
+`logosup` automates the full [Logos Blockchain quickstart](https://github.com/logos-co/logos-docs/blob/main/docs/blockchain/get-started/run-a-logos-blockchain-node-from-cli.md) flow.
 
 ## What `install.sh` does
 

--- a/docs/raspberry-pi-workshop-guide.md
+++ b/docs/raspberry-pi-workshop-guide.md
@@ -242,17 +242,64 @@ Copy the output and save it somewhere safe — a password manager, a printed pie
 
 > **⚠️ Important:** These keys cannot be recovered if lost. Back them up before leaving the workshop.
 
-### Advanced: full data directory backup (for Mainnet)
+### Advanced: Keeping your node secure on Mainnet
 
-*This section is not needed for the workshop — skip it for now.*
-
-If you ever run a mainnet node and want to move your full node state to a new machine, copy the entire data directory from your computer (not the Pi):
+For Mainnet, keep your `logos-node-keys.backup.yaml` file extra secure — store it in a password manager, encrypted storage, or printed and locked away. If you want to also copy the full data directory off the Pi:
 
 ```bash
-scp -r pi@192.168.1.42:~/.logos-node/data/ ./logos-node-data-backup/
+scp -r pi@logos-node.local:/home/pi/.logos ~/logos-backup
 ```
 
-This preserves the RocksDB state directory. For most users, restoring from the key backup alone is sufficient — the node will resync chain data from peers on a fresh install.
+---
+
+## Next Steps — Useful Commands
+
+**Node status:**
+```bash
+logosup status
+```
+Shows whether your node is running, current block height, and how many peers you're connected to. Run this any time you want to check your node is healthy.
+
+**Wallet — check balance:**
+```bash
+logosup wallet balance
+```
+Shows your wallet address and current balance.
+
+**Wallet — send a transfer:**
+```bash
+logosup wallet transfer
+```
+Walks you through sending tokens to another address. Follow the interactive prompts.
+
+**View logs (live):**
+```bash
+logosup logs
+```
+Shows the live output from your node. Press `Ctrl+C` to stop watching. Useful for troubleshooting.
+
+**Stop / start / restart:**
+```bash
+logosup stop
+logosup start
+logosup restart
+```
+
+**Grafana monitoring dashboard:**
+
+If you enabled monitoring during install, open this in your browser to see charts of your node's performance, block sync progress, and peer connections:
+
+```
+https://localhost:3001
+```
+
+Or from another device on the same network: `https://logos-node.local:3001`. Your browser will show a security warning on first visit — accept it to proceed (it's a self-signed certificate generated locally).
+
+**Update the node:**
+```bash
+logosup update
+```
+Downloads and applies the latest version. Run this periodically to stay in sync.
 
 ---
 
@@ -305,7 +352,6 @@ logosup logs --tail=50
 | logosup GitHub | https://github.com/logosnode/logosup |
 | Logos project website | https://logos.co/ |
 | Logos Blockchain quickstart guide | https://github.com/logos-co/logos-docs/blob/main/docs/blockchain/get-started/run-a-logos-blockchain-node-from-cli.md |
-| Manual CLI install guide | https://github.com/logos-co/logos-docs/blob/main/docs/blockchain/get-started/run-a-logos-blockchain-node-from-cli.md |
 | Testnet faucet | https://testnet.blockchain.logos.co/web/faucet/ |
 | Testnet dashboard | https://testnet.blockchain.logos.co/web/ |
 | Raspberry Pi documentation | https://www.raspberrypi.com/documentation/ |

--- a/docs/raspberry-pi-workshop-guide.md
+++ b/docs/raspberry-pi-workshop-guide.md
@@ -1,0 +1,313 @@
+# Setting Up Your Logos Node — Workshop Guide
+
+## Logos Circle Lisbon · [Date placeholder]
+
+Welcome! By the end of this guide you will have a Logos Blockchain node running on a Raspberry Pi, contributing to a decentralised, censorship-resistant network. No prior Linux experience is required — just follow each step in order.
+
+---
+
+## What you'll need
+
+### Hardware
+
+| Item | Notes |
+|------|-------|
+| Raspberry Pi 4 (2 GB RAM or more) | Recommended. Pi 5 also works. Pi 3B+ may work but is not officially tested. |
+| MicroSD card — **32 GB or larger** (Class 10 / A1 rated) | Faster cards mean faster initial setup. |
+| Official Raspberry Pi USB-C power supply (5V / 3A) | A phone charger that under-delivers power will cause random crashes. |
+| Ethernet cable | Wired connection is strongly preferred over Wi-Fi for a node. |
+| Another computer (Windows, Mac, or Linux) | Used to flash the SD card and connect via SSH. |
+| *(Optional)* USB keyboard + HDMI monitor | Useful for first-time troubleshooting if SSH does not work. |
+
+### Software (on your other computer)
+
+| Tool | Where to get it |
+|------|----------------|
+| **Raspberry Pi Imager** | https://www.raspberrypi.com/software/ |
+| **SSH client** | Built into macOS/Linux terminal; Windows: use the built-in OpenSSH or [PuTTY](https://www.putty.org/) |
+
+---
+
+## Step 1: Flash the OS
+
+> **What this does:** Writes the Raspberry Pi operating system onto the SD card so the Pi can boot.
+
+1. Insert your SD card into your computer.
+2. Open **Raspberry Pi Imager**.
+3. Click **Choose Device** → select **Raspberry Pi 4** (or your model).
+4. Click **Choose OS** → **Raspberry Pi OS (other)** → **Raspberry Pi OS Lite (64-bit)**.
+   - "Lite" means no desktop — that is what we want for a headless server.
+5. Click **Choose Storage** → select your SD card.
+6. Click the **gear icon** (or press `Ctrl+Shift+X`) to open **Advanced settings**:
+   - Check **Enable SSH** → select **Use password authentication**.
+   - Set a **hostname** (e.g., `logosnode`).
+   - Set a **username** (e.g., `pi`) and a strong **password** — write this down.
+   - *(Optional)* Configure your Wi-Fi credentials if you are not using ethernet.
+7. Click **Save**, then **Write**. Confirm when prompted.
+
+> **📸 Screenshot placeholder:** *Raspberry Pi Imager — Advanced settings screen showing SSH enabled.*
+
+> **⚠️ Note:** Writing will erase everything on the SD card. Make sure you have the right drive selected.
+
+---
+
+## Step 2: First boot and SSH in
+
+> **What this does:** Powers on the Pi and gives you a terminal window into it from your computer.
+
+1. Insert the flashed SD card into the Raspberry Pi.
+2. Connect the ethernet cable from the Pi to your router.
+3. Connect the power supply — the Pi will boot automatically (no power button).
+4. Wait about 60–90 seconds for the first boot to complete.
+5. Find the Pi's IP address — pick one of these methods:
+   - Log into your **router admin page** (usually `192.168.1.1` or `192.168.0.1`) and look at connected devices. Find the entry named `logosnode`.
+   - Or run this command on your computer (macOS/Linux):
+     ```bash
+     nmap -sn 192.168.1.0/24
+     ```
+     *(Replace `192.168.1.0/24` with your network range if different.)*
+6. Once you have the IP (e.g., `192.168.1.42`), open a terminal and SSH in:
+   ```bash
+   ssh pi@192.168.1.42
+   ```
+   Enter the password you set in Step 1 when prompted.
+
+> **📸 Screenshot placeholder:** *Terminal window showing a successful SSH login to the Pi.*
+
+> **💡 Tip:** On Windows, open PowerShell or Command Prompt and type the same `ssh pi@<IP>` command. OpenSSH is included in Windows 10/11 by default.
+
+---
+
+## Step 3: Update the system
+
+> **What this does:** Downloads and installs the latest security patches and software updates for the operating system. This is good practice before installing anything new.
+
+Run the following two commands one after the other:
+
+```bash
+sudo apt update && sudo apt upgrade -y
+```
+
+This may take a few minutes. You will see a lot of text scrolling — that is normal. When it finishes you will see the command prompt again.
+
+> **💡 Tip:** `sudo` means "run as administrator." On a freshly flashed Pi you will need it for system-level commands.
+
+---
+
+## Step 4: Install Docker
+
+> **What this does:** Installs Docker, the software that packages and runs the Logos node in an isolated container. This is the officially recommended way to run a Logos node.
+
+Run the official Docker install script:
+
+```bash
+curl -fsSL https://get.docker.com | sh
+```
+
+After the script finishes, add your user to the `docker` group so you can run Docker commands without `sudo`:
+
+```bash
+sudo usermod -aG docker $USER
+```
+
+Then **log out and log back in** so the group change takes effect:
+
+```bash
+exit
+```
+
+SSH back in again:
+
+```bash
+ssh pi@192.168.1.42
+```
+
+Verify Docker is working:
+
+```bash
+docker run hello-world
+```
+
+You should see a message saying **"Hello from Docker!"**.
+
+> **🔗 Reference:** Docker documentation — https://docs.docker.com/engine/install/debian/
+
+---
+
+## Step 5: Install logosup
+
+> **What this does:** Downloads the `logosup` tool, which automates everything needed to set up and run a Logos node — downloading the node software, generating your wallet keys, and starting the node.
+
+Run the installer:
+
+```bash
+curl -sL https://raw.githubusercontent.com/logosnode/logosup/main/install.sh | bash
+```
+
+This downloads the `logosup` CLI and makes it available as a command. When it finishes, run the full node setup:
+
+```bash
+logosup install
+```
+
+The installer will:
+1. Download the latest Logos Blockchain release and ZK circuits (this may take several minutes)
+2. Build the Docker image
+3. Generate your **wallet keys** — these are unique cryptographic keys for your node
+4. Detect your public IP address
+5. Optionally set up security hardening (recommended — press `y` when asked)
+6. Optionally set up monitoring with Grafana dashboards (optional for beginners — you can skip with `n`)
+7. Start your node
+
+> **⚠️ Note:** When the installer displays your **wallet keys**, write them down or copy them somewhere safe immediately. These keys are how your node participates in the network and holds any tokens. If you lose them, you cannot recover them.
+
+> **📸 Screenshot placeholder:** *Terminal showing `logosup install` completing and displaying wallet keys.*
+
+---
+
+## Step 6: Verify your node is running
+
+> **What this does:** Confirms that your node has started and is connecting to the Logos network.
+
+Check the node status:
+
+```bash
+logosup status
+```
+
+You should see output including:
+- **Consensus mode**: starts as `Bootstrapping`, changes to `Online` after syncing with peers
+- **Peer count**: number of other nodes your node is connected to
+- **Wallet balances** for your keys
+
+To see the live logs:
+
+```bash
+logosup logs -f
+```
+
+Press `Ctrl+C` to stop following the logs.
+
+> **💡 Tip:** It is normal for the node to show `Bootstrapping` for the first 10–30 minutes while it finds peers and syncs. Check the [testnet dashboard](https://testnet.blockchain.logos.co/web/) to see the overall network state.
+
+---
+
+## Step 7: Port forwarding (if needed)
+
+> **What this does:** Allows other nodes on the internet to connect to your node directly, making the network stronger.
+
+The Logos node uses **port 3000/UDP** for peer-to-peer connections. If your Pi is behind a home router (which it almost certainly is), you may need to tell your router to forward this port to the Pi.
+
+Steps vary by router brand. In general:
+
+1. Log into your router admin page (usually `192.168.1.1`)
+2. Find **Port Forwarding** (sometimes under "Advanced" or "NAT")
+3. Create a new rule:
+   - **Protocol**: UDP
+   - **External port**: 3000
+   - **Internal IP**: your Pi's IP address (e.g., `192.168.1.42`)
+   - **Internal port**: 3000
+4. Save and apply
+
+> **🔗 Reference:** Generic port forwarding guide — https://portforward.com/
+
+> **💡 Tip:** If you are not sure whether port forwarding is needed, check `logosup status` after your node has been running for 30+ minutes. If peer count is greater than 0, you are already connected to the network.
+
+---
+
+## Step 8: Back up your node
+
+> **What this does:** Saves a copy of your wallet keys and configuration so you can restore your node if the SD card fails or if you move to a new Pi.
+
+### What to back up
+
+The most important files are in `~/.logos-node/` on the Pi:
+
+| File/Directory | Why it matters |
+|----------------|---------------|
+| `~/.logos-node/user_config.yaml` | Your node configuration including generated keys |
+| `~/.logos-node/data/` | Node state (RocksDB) — large, but good to back up periodically |
+
+### How to back up
+
+From your computer (not the Pi), run:
+
+```bash
+scp pi@192.168.1.42:~/.logos-node/user_config.yaml ./logos-node-config-backup.yaml
+```
+
+To back up the full data directory:
+
+```bash
+scp -r pi@192.168.1.42:~/.logos-node/data/ ./logos-node-data-backup/
+```
+
+> **💡 Tip:** You can also copy files to a USB drive plugged into the Pi, using `cp ~/.logos-node/user_config.yaml /media/usb/logos-node-config-backup.yaml` (mount path may vary).
+
+### How often to back up
+
+- **`user_config.yaml`**: Back up immediately after install and any time you change configuration. This file rarely changes.
+- **`data/` directory**: Weekly or before any software update is a good habit.
+
+> **📸 Screenshot placeholder:** *Terminal showing `scp` command completing successfully.*
+
+---
+
+## Troubleshooting
+
+### The Pi won't boot / I can't SSH in
+
+- Make sure the power supply is the official Raspberry Pi one. Under-powered supplies are the most common cause of boot failures.
+- Check that the SD card is fully inserted.
+- Try connecting a monitor and keyboard to see if there are any error messages on screen.
+- Re-flash the SD card — sometimes a write error during flashing causes issues.
+
+### `logosup` command not found after install
+
+The install script adds `logosup` to your PATH, but this only takes effect in new shell sessions. Try:
+
+```bash
+source ~/.bashrc
+```
+
+Or log out and back in via SSH.
+
+### Node stays in "Bootstrapping" mode for a long time
+
+- Check that your internet connection is working: `ping google.com`
+- Check that Docker is running: `docker ps`
+- Check port forwarding (Step 7) — your node may not be reachable by peers
+- Try restarting the node: `logosup stop && logosup start`
+
+### Node was running but stopped after a Pi reboot
+
+The node is configured with `restart: unless-stopped`, so it should start automatically on reboot. If it did not:
+
+```bash
+logosup start
+```
+
+If that fails, check the logs for errors:
+
+```bash
+logosup logs --tail=50
+```
+
+---
+
+## Resources
+
+| Resource | Link |
+|----------|------|
+| logosup GitHub | https://github.com/logosnode/logosup |
+| Logos project website | https://logos.co/ |
+| Logos Blockchain quickstart guide | https://github.com/logos-co/logos-docs/blob/main/docs/blockchain/quickstart-guide-for-the-logos-blockchain-node.md |
+| Testnet faucet | https://testnet.blockchain.logos.co/web/faucet/ |
+| Testnet dashboard | https://testnet.blockchain.logos.co/web/ |
+| Raspberry Pi documentation | https://www.raspberrypi.com/documentation/ |
+| Docker documentation | https://docs.docker.com/ |
+| Logos Circle Lisbon | *[Contact placeholder — add your group link or email here]* |
+
+---
+
+*Guide prepared for Logos Circle Lisbon workshop participants. Contributions and corrections welcome — open an issue or pull request on the repository.*

--- a/docs/raspberry-pi-workshop-guide.md
+++ b/docs/raspberry-pi-workshop-guide.md
@@ -46,7 +46,7 @@ Welcome! By the end of this guide you will have a Logos Blockchain node running 
    - Set your **locale and timezone** (e.g., `Europe/Lisbon`).
 7. Click **Save**, then **Write**. Confirm when prompted.
 
-> **📸 Screenshot placeholder:** *Raspberry Pi Imager — Advanced Options screen showing SSH enabled, hostname, and WiFi configured.*
+The Advanced Options screen should show SSH toggled on, your chosen hostname (e.g. `logos-node`), and the WiFi credentials filled in before you proceed.
 
 > **⚠️ Note:** Writing will erase everything on the SD card. Make sure you have the right drive selected.
 
@@ -107,7 +107,7 @@ Replace `WorkshopWiFi` / `workshoppassword` and `HomeWiFi` / `homepassword` with
    ```
    Enter the password you set in Step 1 when prompted.
 
-> **📸 Screenshot placeholder:** *Terminal window showing a successful SSH login to the Pi.*
+On a successful login you'll see a Raspberry Pi OS welcome banner followed by a prompt like `pi@logos-node:~ $`.
 
 > **💡 Tip:** On Windows, open PowerShell or Command Prompt and type the same `ssh pi@<IP>` command. OpenSSH is included in Windows 10/11 by default.
 
@@ -158,7 +158,7 @@ The installer will:
 
 > **⚠️ Note:** When the installer displays your **wallet keys**, write them down or copy them somewhere safe immediately. These keys are how your node participates in the network and holds any tokens. If you lose them, you cannot recover them.
 
-> **📸 Screenshot placeholder:** *Terminal showing `logosup install` completing and displaying wallet keys.*
+Once the installer finishes, the terminal will print your wallet public key and private key. Copy these to a safe location before continuing — they will not be shown again.
 
 ---
 
@@ -304,7 +304,7 @@ logosup logs --tail=50
 |----------|------|
 | logosup GitHub | https://github.com/logosnode/logosup |
 | Logos project website | https://logos.co/ |
-| Logos Blockchain quickstart guide | https://github.com/logos-co/logos-docs/blob/main/docs/blockchain/quickstart-guide-for-the-logos-blockchain-node.md |
+| Logos Blockchain quickstart guide | https://github.com/logos-co/logos-docs/blob/main/docs/blockchain/get-started/run-a-logos-blockchain-node-from-cli.md |
 | Manual CLI install guide | https://github.com/logos-co/logos-docs/blob/main/docs/blockchain/get-started/run-a-logos-blockchain-node-from-cli.md |
 | Testnet faucet | https://testnet.blockchain.logos.co/web/faucet/ |
 | Testnet dashboard | https://testnet.blockchain.logos.co/web/ |

--- a/docs/raspberry-pi-workshop-guide.md
+++ b/docs/raspberry-pi-workshop-guide.md
@@ -1,6 +1,6 @@
 # Setting Up Your Logos Node — Workshop Guide
 
-## Logos Circle Lisbon · [Date placeholder]
+## Logos Circle Lisbon · June 10, 2026
 
 Welcome! By the end of this guide you will have a Logos Blockchain node running on a Raspberry Pi, contributing to a decentralised, censorship-resistant network. No prior Linux experience is required — just follow each step in order.
 
@@ -38,16 +38,51 @@ Welcome! By the end of this guide you will have a Logos Blockchain node running 
 4. Click **Choose OS** → **Raspberry Pi OS (other)** → **Raspberry Pi OS Lite (64-bit)**.
    - "Lite" means no desktop — that is what we want for a headless server.
 5. Click **Choose Storage** → select your SD card.
-6. Click the **gear icon** (or press `Ctrl+Shift+X`) to open **Advanced settings**:
+6. Click the **⚙️ gear icon** (or press `Ctrl+Shift+X`) to open **Advanced Options**:
+   - Set a **hostname** — use `logos-node` (this is the name your Pi will advertise on the network).
    - Check **Enable SSH** → select **Use password authentication**.
-   - Set a **hostname** (e.g., `logosnode`).
    - Set a **username** (e.g., `pi`) and a strong **password** — write this down.
-   - *(Optional)* Configure your Wi-Fi credentials if you are not using ethernet.
+   - Enter your **WiFi SSID and password** for the workshop network.
+   - Set your **locale and timezone** (e.g., `Europe/Lisbon`).
 7. Click **Save**, then **Write**. Confirm when prompted.
 
-> **📸 Screenshot placeholder:** *Raspberry Pi Imager — Advanced settings screen showing SSH enabled.*
+> **📸 Screenshot placeholder:** *Raspberry Pi Imager — Advanced Options screen showing SSH enabled, hostname, and WiFi configured.*
 
 > **⚠️ Note:** Writing will erase everything on the SD card. Make sure you have the right drive selected.
+
+### Adding a second WiFi network (home + workshop)
+
+Raspberry Pi Imager only lets you enter one WiFi network. If you want the Pi to also connect to your home network automatically when you bring it back, you can add it by editing the SD card directly after flashing.
+
+**The file to edit:** `wpa_supplicant.conf` on the `boot` partition of the SD card.
+
+- **Windows**: the `boot` partition appears as a drive in File Explorer (e.g., `D:\`).
+- **Mac**: it mounts in Finder automatically (look for `boot` on the desktop or in the sidebar).
+- **Linux**: it mounts automatically at `/media/<user>/boot` or similar.
+
+Open `wpa_supplicant.conf` in any text editor and replace its contents with:
+
+```
+country=PT
+ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
+update_config=1
+
+network={
+    ssid="WorkshopWiFi"
+    psk="workshoppassword"
+    priority=1
+}
+
+network={
+    ssid="HomeWiFi"
+    psk="homepassword"
+    priority=2
+}
+```
+
+Replace `WorkshopWiFi` / `workshoppassword` and `HomeWiFi` / `homepassword` with your actual credentials. **Higher priority number = tried first**, so setting home WiFi to `priority=2` means the Pi will connect home when it is back from the workshop.
+
+> **💡 Tip:** If you already set a WiFi in Imager's Advanced Options, you will see a `network={...}` block already in the file. You can add a second `network={...}` block below it — the Pi will try both.
 
 ---
 
@@ -60,7 +95,7 @@ Welcome! By the end of this guide you will have a Logos Blockchain node running 
 3. Connect the power supply — the Pi will boot automatically (no power button).
 4. Wait about 60–90 seconds for the first boot to complete.
 5. Find the Pi's IP address — pick one of these methods:
-   - Log into your **router admin page** (usually `192.168.1.1` or `192.168.0.1`) and look at connected devices. Find the entry named `logosnode`.
+   - Log into your **router admin page** (usually `192.168.1.1` or `192.168.0.1`) and look at connected devices. Find the entry named `logos-node`.
    - Or run this command on your computer (macOS/Linux):
      ```bash
      nmap -sn 192.168.1.0/24
@@ -94,49 +129,11 @@ This may take a few minutes. You will see a lot of text scrolling — that is no
 
 ---
 
-## Step 4: Install Docker
+## Step 4: Install logosup
 
-> **What this does:** Installs Docker, the software that packages and runs the Logos node in an isolated container. This is the officially recommended way to run a Logos node.
+> **What this does:** Downloads the `logosup` tool, which automates everything needed to set up and run a Logos node — including Docker setup, downloading the node software, generating your wallet keys, and starting the node.
 
-Run the official Docker install script:
-
-```bash
-curl -fsSL https://get.docker.com | sh
-```
-
-After the script finishes, add your user to the `docker` group so you can run Docker commands without `sudo`:
-
-```bash
-sudo usermod -aG docker $USER
-```
-
-Then **log out and log back in** so the group change takes effect:
-
-```bash
-exit
-```
-
-SSH back in again:
-
-```bash
-ssh pi@192.168.1.42
-```
-
-Verify Docker is working:
-
-```bash
-docker run hello-world
-```
-
-You should see a message saying **"Hello from Docker!"**.
-
-> **🔗 Reference:** Docker documentation — https://docs.docker.com/engine/install/debian/
-
----
-
-## Step 5: Install logosup
-
-> **What this does:** Downloads the `logosup` tool, which automates everything needed to set up and run a Logos node — downloading the node software, generating your wallet keys, and starting the node.
+> **Note on Docker:** `logosup` handles Docker automatically — you don't need to install it separately. If you prefer to set everything up manually (recommended for production/mainnet), follow the [official CLI guide](https://github.com/logos-co/logos-docs/blob/main/docs/blockchain/get-started/run-a-logos-blockchain-node-from-cli.md). For this workshop we'll use `logosup` which automates the entire Docker setup.
 
 Run the installer:
 
@@ -165,7 +162,7 @@ The installer will:
 
 ---
 
-## Step 6: Verify your node is running
+## Step 5: Verify your node is running
 
 > **What this does:** Confirms that your node has started and is connecting to the Logos network.
 
@@ -192,13 +189,17 @@ Press `Ctrl+C` to stop following the logs.
 
 ---
 
-## Step 7: Port forwarding (if needed)
+## Step 6: Port forwarding (optional — for better connectivity)
 
-> **What this does:** Allows other nodes on the internet to connect to your node directly, making the network stronger.
+> **What this does:** Allows other nodes on the internet to connect to your node directly, which improves peer discovery and makes the network stronger.
 
-The Logos node uses **port 3000/UDP** for peer-to-peer connections. If your Pi is behind a home router (which it almost certainly is), you may need to tell your router to forward this port to the Pi.
+**Port forwarding is not strictly required for the workshop.** Your node can connect outbound to bootstrap peers and participate in the testnet without it. If your peer count stays at 0 after 30 minutes, it is worth trying.
 
-Steps vary by router brand. In general:
+The Logos node uses **port 3000/UDP** for peer-to-peer connections. If your Pi is behind a home router (which it almost certainly is), forwarding this port lets other nodes reach yours directly.
+
+> **💡 Check UPnP first:** Many modern routers support UPnP (Universal Plug and Play), which can handle port forwarding automatically without any manual steps. Log into your router admin page and look for a UPnP setting — if it is enabled, port forwarding may already be working.
+
+If you need to set it up manually, the general steps are:
 
 1. Log into your router admin page (usually `192.168.1.1`)
 2. Find **Port Forwarding** (sometimes under "Advanced" or "NAT")
@@ -209,47 +210,49 @@ Steps vary by router brand. In general:
    - **Internal port**: 3000
 4. Save and apply
 
-> **🔗 Reference:** Generic port forwarding guide — https://portforward.com/
+> **🔗 Reference:** Generic port forwarding guide — https://www.wikihow.com/Set-Up-Port-Forwarding-on-a-Router
 
-> **💡 Tip:** If you are not sure whether port forwarding is needed, check `logosup status` after your node has been running for 30+ minutes. If peer count is greater than 0, you are already connected to the network.
+> **💡 Tip:** Run `logosup status` after your node has been running for 30+ minutes. If peer count is greater than 0, you are already connected to the network and port forwarding is working or not needed.
 
 ---
 
-## Step 8: Back up your node
+## Step 7: Back up your node
 
-> **What this does:** Saves a copy of your wallet keys and configuration so you can restore your node if the SD card fails or if you move to a new Pi.
+> **What this does:** Saves a copy of your wallet keys so you can restore your node if the SD card fails or if you move to a new Pi.
 
-### What to back up
-
-The most important files are in `~/.logos-node/` on the Pi:
-
-| File/Directory | Why it matters |
-|----------------|---------------|
-| `~/.logos-node/user_config.yaml` | Your node configuration including generated keys |
-| `~/.logos-node/data/` | Node state (RocksDB) — large, but good to back up periodically |
-
-### How to back up
-
-From your computer (not the Pi), run:
+Run this command on the Pi:
 
 ```bash
-scp pi@192.168.1.42:~/.logos-node/user_config.yaml ./logos-node-config-backup.yaml
+logosup keys backup
 ```
 
-To back up the full data directory:
+Output looks like:
+
+```
+✔ Wallet keys backed up to logos-node-keys.backup.yaml
+```
+
+Then display the backup file:
+
+```bash
+cat logos-node-keys.backup.yaml
+```
+
+Copy the output and save it somewhere safe — a password manager, a printed piece of paper, or an encrypted note. That is all you need for the workshop.
+
+> **⚠️ Important:** These keys cannot be recovered if lost. Back them up before leaving the workshop.
+
+### Advanced: full data directory backup (for Mainnet)
+
+*This section is not needed for the workshop — skip it for now.*
+
+If you ever run a mainnet node and want to move your full node state to a new machine, copy the entire data directory from your computer (not the Pi):
 
 ```bash
 scp -r pi@192.168.1.42:~/.logos-node/data/ ./logos-node-data-backup/
 ```
 
-> **💡 Tip:** You can also copy files to a USB drive plugged into the Pi, using `cp ~/.logos-node/user_config.yaml /media/usb/logos-node-config-backup.yaml` (mount path may vary).
-
-### How often to back up
-
-- **`user_config.yaml`**: Back up immediately after install and any time you change configuration. This file rarely changes.
-- **`data/` directory**: Weekly or before any software update is a good habit.
-
-> **📸 Screenshot placeholder:** *Terminal showing `scp` command completing successfully.*
+This preserves the RocksDB state directory. For most users, restoring from the key backup alone is sufficient — the node will resync chain data from peers on a fresh install.
 
 ---
 
@@ -276,7 +279,7 @@ Or log out and back in via SSH.
 
 - Check that your internet connection is working: `ping google.com`
 - Check that Docker is running: `docker ps`
-- Check port forwarding (Step 7) — your node may not be reachable by peers
+- Check port forwarding (Step 6) — your node may not be reachable by peers
 - Try restarting the node: `logosup stop && logosup start`
 
 ### Node was running but stopped after a Pi reboot
@@ -302,10 +305,12 @@ logosup logs --tail=50
 | logosup GitHub | https://github.com/logosnode/logosup |
 | Logos project website | https://logos.co/ |
 | Logos Blockchain quickstart guide | https://github.com/logos-co/logos-docs/blob/main/docs/blockchain/quickstart-guide-for-the-logos-blockchain-node.md |
+| Manual CLI install guide | https://github.com/logos-co/logos-docs/blob/main/docs/blockchain/get-started/run-a-logos-blockchain-node-from-cli.md |
 | Testnet faucet | https://testnet.blockchain.logos.co/web/faucet/ |
 | Testnet dashboard | https://testnet.blockchain.logos.co/web/ |
 | Raspberry Pi documentation | https://www.raspberrypi.com/documentation/ |
 | Docker documentation | https://docs.docker.com/ |
+| Port forwarding guide | https://www.wikihow.com/Set-Up-Port-Forwarding-on-a-Router |
 | Logos Circle Lisbon | *[Contact placeholder — add your group link or email here]* |
 
 ---


### PR DESCRIPTION
## Summary

- Adds `docs/raspberry-pi-workshop-guide.md` — a complete, beginner-friendly step-by-step guide for setting up a Logos node on a Raspberry Pi
- Written for non-technical participants at a Logos Circle community workshop
- Covers everything from flashing the SD card to running and backing up a node

## Guide contents

1. Hardware and software requirements
2. Flashing Raspberry Pi OS Lite (64-bit) with SSH pre-enabled
3. First boot and SSH connection
4. System update
5. Docker installation (official install script)
6. `logosup install` walkthrough
7. Verifying the node is running (`logosup status`, `logosup logs`)
8. Port forwarding (port 3000/UDP)
9. Backing up `user_config.yaml` and the data directory via `scp`
10. Troubleshooting section (4 common issues)
11. Resources and links

## Notes

- Uses `> **💡 Tip:**` and `> **⚠️ Note:**` callout boxes throughout
- Screenshot placeholders mark where workshop facilitators can insert actual screenshots
- Tone is friendly and assumes no prior Linux knowledge
- All commands are in fenced code blocks with plain-English "What this does:" explanations